### PR TITLE
Perms changes

### DIFF
--- a/src/main/java/pro/dracarys/LocketteX/listener/InventoryOpen.java
+++ b/src/main/java/pro/dracarys/LocketteX/listener/InventoryOpen.java
@@ -23,7 +23,7 @@ public class InventoryOpen implements Listener {
         if (!Util.isEnabledWorld(e.getPlayer().getWorld().getName()) || !(e.getPlayer() instanceof Player) || e.getInventory().getHolder() == null)
             return;
         Player p = (Player) e.getPlayer();
-        if (p.isOp()
+        if (p.isOp() || p.hasPermission(Config.PERMISSION_ADMIN.getString())
                 || (Config.PROTECT_CLAIMED_ONLY.getOption() && ClaimUtil.isClaimedAt(p.getLocation()))
                 || (Config.LEADER_CAN_OPEN.getOption() && ClaimUtil.getLeaderAt(p.getLocation()).equalsIgnoreCase(p.getName())))
             return;

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -11,3 +11,9 @@ commands:
     description: Main Command
     usage: "Usage: /<command>"
     aliases: [ protect ]
+permissions:
+  lockettex:
+    admin:
+      description: "Allows player to open any chests"
+    create:
+      description: "Allows player to create locked chests"


### PR DESCRIPTION
Added perms in plugin.yml and allowed players with admin permission to open everyone's chests.
Not sure if that's how you intended the plugin to work but that is what fixes my issue as I need some players to be able to open everyone's chests without them being op.