### PR TITLE
ProtectionStones support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
   - [x] MCore Factions
 - [x] Towny
 - [x] Lands
+- [x] ProtectionStones (1.17.x - 1.19.x)
 
 **Maven - Build Command:**
 `mvn clean package`

--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,11 @@
             <id>savagelabs</id>
             <url>https://nexus.savagelabs.net/repository/maven-public/</url>
         </repository>
+        <!-- WorldGuard repository -->
+        <repository>
+            <id>sk89q-repo</id>
+            <url>https://maven.enginehub.org/repo/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -123,7 +128,7 @@
         <dependency>
             <groupId>com.github.PikaMug</groupId>
             <artifactId>LocaleLib</artifactId>
-            <version>2.8</version>
+            <version>3.1</version>
             <scope>compile</scope>
         </dependency>
 
@@ -202,6 +207,13 @@
             <version>RC-29</version>
             <scope>provided</scope>
             <!-- ... -->
+        </dependency>
+        <!-- WorldGuard -->
+        <dependency>
+            <groupId>com.sk89q.worldguard</groupId>
+            <artifactId>worldguard-bukkit</artifactId>
+            <version>7.0.0</version>
+            <scope>provided</scope>
         </dependency>
         <!-- Vault -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>pro.dracarys</groupId>
     <artifactId>LocketteX</artifactId>
     <name>LocketteX</name>
-    <version>1.7.8</version>
+    <version>1.7.9</version>
     <packaging>jar</packaging>
     <url>https://dracarys.pro</url>
 

--- a/src/main/java/pro/dracarys/LocketteX/config/Config.java
+++ b/src/main/java/pro/dracarys/LocketteX/config/Config.java
@@ -34,6 +34,7 @@ public enum Config {
     PERMISSION_CREATION("Permissions.permission-creation", "lockettex.create"),
 
     USE_GRIEFPREVENTION("Hooks.griefprevention.deny-if-no-build-perm", true),
+    USE_PROTECTIONSTONES("Hooks.protectionstones.protect-only-in-region", true),
     DISABLE_CLAIM_HOOKS("Hooks.disable-hooking-to-claim-plugins", false),
     LEADER_CAN_BREAK("Hooks.leader-bypasses-break-protection", false),
     LEADER_CAN_OPEN("Hooks.leader-bypasses-open-protection", false),

--- a/src/main/java/pro/dracarys/LocketteX/hooks/HookManager.java
+++ b/src/main/java/pro/dracarys/LocketteX/hooks/HookManager.java
@@ -18,6 +18,8 @@ public class HookManager {
         hookPlugin(new SlimefunHook());
         if (Config.USE_GRIEFPREVENTION.getOption())
             hookPlugin(new GriefPreventionHook());
+
+        if (Config.USE_PROTECTIONSTONES.getOption()) hookPlugin(new ProtectionStonesHook());
     }
 
     private void hookPlugin(PluginHook<?> pluginHook) {

--- a/src/main/java/pro/dracarys/LocketteX/hooks/ProtectionStonesHook.java
+++ b/src/main/java/pro/dracarys/LocketteX/hooks/ProtectionStonesHook.java
@@ -1,0 +1,36 @@
+package pro.dracarys.LocketteX.hooks;
+
+import com.sk89q.worldedit.bukkit.BukkitAdapter;
+import com.sk89q.worldguard.WorldGuard;
+import com.sk89q.worldguard.protection.ApplicableRegionSet;
+import com.sk89q.worldguard.protection.regions.ProtectedRegion;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+import pro.dracarys.LocketteX.hooks.claim.ClaimPlugin;
+
+public class ProtectionStonesHook extends ClaimPlugin {
+
+    @Override
+    public ProtectionStonesHook setup(JavaPlugin plugin) {
+        return this;
+    }
+
+    public boolean isInOwnedProtection(Player player, Location location) {
+        ApplicableRegionSet regions = WorldGuard.getInstance().getPlatform()
+                .getRegionContainer().createQuery().getApplicableRegions(BukkitAdapter.adapt(location));
+
+        for (ProtectedRegion region : regions) {
+            if (region.getMembers().contains(player.getUniqueId())
+                || region.getOwners().contains(player.getUniqueId())) return true;
+        }
+
+        return false;
+    }
+
+    @Override
+    public String getName() {
+        return "ProtectionStones";
+    }
+
+}

--- a/src/main/java/pro/dracarys/LocketteX/hooks/claim/ClaimPlugin.java
+++ b/src/main/java/pro/dracarys/LocketteX/hooks/claim/ClaimPlugin.java
@@ -5,6 +5,7 @@ import org.bukkit.Location;
 import org.bukkit.plugin.java.JavaPlugin;
 import pro.dracarys.LocketteX.config.Message;
 import pro.dracarys.LocketteX.hooks.PluginHook;
+import pro.dracarys.LocketteX.hooks.ProtectionStonesHook;
 import pro.dracarys.LocketteX.utils.Util;
 
 import java.util.List;
@@ -54,6 +55,11 @@ public class ClaimPlugin implements PluginHook<ClaimPlugin> {
             hookedPlugin = "Lands";
             Util.sendConsole(Message.PREFIX.getMessage() + Message.CLAIM_HOOK_FOUND.getMessage().replace("%plugin%", hookedPlugin));
             return new LandsHook();
+        }
+        if (Bukkit.getPluginManager().isPluginEnabled("ProtectionStones")) {
+            hookedPlugin = "ProtectionStones";
+            Util.sendConsole(Message.PREFIX.getMessage() + Message.CLAIM_HOOK_FOUND.getMessage().replace("%plugin%", hookedPlugin));
+            return new ProtectionStonesHook();
         }
         Util.sendConsole(Message.PREFIX.getMessage() + Message.CLAIM_HOOK_NOTFOUND.getMessage());
         hookedPlugin = "none";

--- a/src/main/java/pro/dracarys/LocketteX/listener/BlockPlace.java
+++ b/src/main/java/pro/dracarys/LocketteX/listener/BlockPlace.java
@@ -19,6 +19,7 @@ import pro.dracarys.LocketteX.config.Config;
 import pro.dracarys.LocketteX.config.Message;
 import pro.dracarys.LocketteX.data.SignUser;
 import pro.dracarys.LocketteX.hooks.GriefPreventionHook;
+import pro.dracarys.LocketteX.hooks.ProtectionStonesHook;
 import pro.dracarys.LocketteX.hooks.VaultHook;
 import pro.dracarys.LocketteX.utils.Util;
 
@@ -47,6 +48,13 @@ public class BlockPlace implements Listener {
                 if (LocketteX.getInstance().getHookManager().getHookedPlugins().contains("GriefPrevention")) {
                     GriefPreventionHook gpHook = (GriefPreventionHook) LocketteX.getInstance().getHookManager().getHookedPluginsMap().get("GriefPrevention");
                     if (!gpHook.canBuildAt(e.getPlayer(), e.getBlockAgainst().getLocation())) {
+                        e.getPlayer().sendMessage(Message.PREFIX.getMessage() + Message.GP_HOOK_CANT_PROTECT.getMessage());
+                        return;
+                    }
+                }
+                if (LocketteX.getInstance().getHookManager().getHookedPlugins().contains("ProtectionStones")) {
+                    ProtectionStonesHook psHook = (ProtectionStonesHook) LocketteX.getInstance().getHookManager().getHookedPluginsMap().get("ProtectionStones");
+                    if (!psHook.isInOwnedProtection(e.getPlayer(), e.getBlockAgainst().getLocation())) {
                         e.getPlayer().sendMessage(Message.PREFIX.getMessage() + Message.GP_HOOK_CANT_PROTECT.getMessage());
                         return;
                     }

--- a/src/main/java/pro/dracarys/LocketteX/listener/SignChange.java
+++ b/src/main/java/pro/dracarys/LocketteX/listener/SignChange.java
@@ -17,6 +17,7 @@ import pro.dracarys.LocketteX.config.Config;
 import pro.dracarys.LocketteX.config.Message;
 import pro.dracarys.LocketteX.data.SignUser;
 import pro.dracarys.LocketteX.hooks.GriefPreventionHook;
+import pro.dracarys.LocketteX.hooks.ProtectionStonesHook;
 import pro.dracarys.LocketteX.hooks.VaultHook;
 import pro.dracarys.LocketteX.utils.ClaimUtil;
 import pro.dracarys.LocketteX.utils.Util;
@@ -85,7 +86,13 @@ public class SignChange implements Listener {
                 return;
             }
         }
-
+        if (LocketteX.getInstance().getHookManager().getHookedPlugins().contains("ProtectionStones")) {
+            ProtectionStonesHook psHook = (ProtectionStonesHook) LocketteX.getInstance().getHookManager().getHookedPluginsMap().get("ProtectionStones");
+            if (!psHook.isInOwnedProtection(e.getPlayer(), attachedBlock.getLocation())) {
+                e.getPlayer().sendMessage(Message.PREFIX.getMessage() + Message.GP_HOOK_CANT_PROTECT.getMessage());
+                return;
+            }
+        }
         PlayerProtectBlockEvent protectEvent = new PlayerProtectBlockEvent(e.getPlayer(), attachedBlock);
         Bukkit.getPluginManager().callEvent(protectEvent);
         if (protectEvent.isCancelled()) return;

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -6,6 +6,7 @@ version: "${project.version}"
 description: "${project.description}"
 api-version: '1.13'
 softdepend: [ Vault,ChestShop,Factions,FactionsX,Feudal,Lands,MassiveCore,SkyblockX,Slimefun,Towny,HolographicDisplays,GriefPrevention ]
+depend: [ProtectionStones]
 commands:
   lockettex:
     description: Main Command

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -5,8 +5,7 @@ prefix: "${project.name}"
 version: "${project.version}"
 description: "${project.description}"
 api-version: '1.13'
-softdepend: [ Vault,ChestShop,Factions,FactionsX,Feudal,Lands,MassiveCore,SkyblockX,Slimefun,Towny,HolographicDisplays,GriefPrevention ]
-depend: [ProtectionStones]
+softdepend: [ Vault,ChestShop,Factions,FactionsX,Feudal,Lands,MassiveCore,SkyblockX,Slimefun,Towny,HolographicDisplays,GriefPrevention, ProtectionStones ]
 commands:
   lockettex:
     description: Main Command


### PR DESCRIPTION
I just added a way to prevent players from protecting containers outside the protections where they have build permissions.

This means that, if enabled, players can only protect containers in the ProtectionStones regions which they own or are a member.