### PR TITLE
Block changing of protected sign

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>pro.dracarys</groupId>
     <artifactId>LocketteX</artifactId>
     <name>LocketteX</name>
-    <version>1.8.0</version>
+    <version>1.8.1</version>
     <packaging>jar</packaging>
     <url>https://dracarys.pro</url>
 

--- a/src/main/java/pro/dracarys/LocketteX/listener/SignChange.java
+++ b/src/main/java/pro/dracarys/LocketteX/listener/SignChange.java
@@ -1,6 +1,7 @@
 package pro.dracarys.LocketteX.listener;
 
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.block.Block;
 import org.bukkit.block.Sign;
 import org.bukkit.block.data.Directional;
@@ -29,8 +30,20 @@ public class SignChange implements Listener {
         if (!Util.isEnabledWorld(e.getPlayer().getWorld().getName())) {
             return;
         }
+
+        if (e.getBlock().getState() instanceof Sign) {
+            Sign sign = (Sign) e.getBlock().getState();
+            String oldLine = ChatColor.stripColor(sign.getLine(0));
+
+            if (oldLine.equalsIgnoreCase(Config.SIGN_ID_LINE.getString()) && !LocketteXAPI.canBreak(e.getPlayer(), e.getBlock())) {
+                e.setCancelled(true);
+                return;
+            }
+        }
+
         String line0 = e.getLine(0);
         if (line0 == null || !line0.equalsIgnoreCase(Config.SIGN_ID_LINE.getString())) return;
+
         // From this point forward we're sure the player is trying to create a [Protect] sign
         if (!Config.PERMISSION_FOR_ALL.getOption() && !e.getPlayer().hasPermission(Config.PERMISSION_CREATION.getString())) {
             e.getPlayer().sendMessage(Message.PREFIX.getMessage() + Message.CREATION_NOPERMISSION.getMessage());

--- a/src/main/java/pro/dracarys/LocketteX/listener/SignChange.java
+++ b/src/main/java/pro/dracarys/LocketteX/listener/SignChange.java
@@ -43,7 +43,6 @@ public class SignChange implements Listener {
 
         String line0 = e.getLine(0);
         if (line0 == null || !line0.equalsIgnoreCase(Config.SIGN_ID_LINE.getString())) return;
-
         // From this point forward we're sure the player is trying to create a [Protect] sign
         if (!Config.PERMISSION_FOR_ALL.getOption() && !e.getPlayer().hasPermission(Config.PERMISSION_CREATION.getString())) {
             e.getPlayer().sendMessage(Message.PREFIX.getMessage() + Message.CREATION_NOPERMISSION.getMessage());


### PR DESCRIPTION
In the current version a other player can edit the content of a sign. After changing the content he can access the protected block. 

In this PR I fixed this.