### PR TITLE
Change the method of get server version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>pro.dracarys</groupId>
     <artifactId>LocketteX</artifactId>
     <name>LocketteX</name>
-    <version>1.8.0</version>
+    <version>1.8.1</version>
     <packaging>jar</packaging>
     <url>https://dracarys.pro</url>
 
@@ -120,13 +120,17 @@
             <scope>compile</scope>
         </dependency>
         <!-- LocaleLib -->
+<!--        <dependency>-->
+<!--            <groupId>com.github.PikaMug</groupId>-->
+<!--            <artifactId>LocaleLib</artifactId>-->
+<!--            <version>3.1</version>-->
+<!--            <scope>compile</scope>-->
+<!--        </dependency>-->
         <dependency>
             <groupId>com.github.PikaMug</groupId>
             <artifactId>LocaleLib</artifactId>
-            <version>3.1</version>
-            <scope>compile</scope>
+            <version>-SNAPSHOT</version>
         </dependency>
-
         <!-- HolographicDisplays -->
         <dependency>
             <groupId>com.gmail.filoghost.holographicdisplays</groupId>

--- a/src/main/java/pro/dracarys/LocketteX/LocketteX.java
+++ b/src/main/java/pro/dracarys/LocketteX/LocketteX.java
@@ -109,7 +109,7 @@ public class LocketteX extends JavaPlugin {
     private static int ver;
 
     private static void checkServerVersion() {
-        ver = Integer.parseInt(Bukkit.getServer().getClass().getPackage().getName().replace(".", ",").split(",")[3].replace("1_", "").substring(1).replaceAll("_R\\d", ""));
+        ver = Integer.parseInt(Bukkit.getServer().getBukkitVersion().substring(2,4));
     }
 
     public static int getServerVersion() {


### PR DESCRIPTION

 >  As already announced before, at some point in the foreseeable future, we will remove the CraftBukkit package relocation (e.g. v1_20_R3). This may be as soon as 1.20.5, as we expect almost every plugin using internals to break due to major changes in vanilla anyways.  https://forums.papermc.io/threads/important-dev-psa-future-removal-of-cb-package-relocation.1106/

Change the method of get server version. 1.20.5+ removed the CraftBukkit package relocation.